### PR TITLE
Adding repo instructions

### DIFF
--- a/.github/instructions/BRAZILIAN-TRANSLATIONS.instructions.md
+++ b/.github/instructions/BRAZILIAN-TRANSLATIONS.instructions.md
@@ -1,0 +1,113 @@
+# Brazilian Portuguese Translation Maintenance Instructions
+
+## Project Overview
+
+WordPress Playground documentation requires Brazilian Portuguese (pt-BR) translations to stay synchronized with English updates and new page additions on trunk. All Portuguese translations are stored in `packages/docs/site/i18n/pt/docusaurus-plugin-content-docs/current/` following the exact structure of `packages/docs/site/docs/`.
+
+## Portuguese Translation File Structure
+
+- Original English: `packages/docs/site/docs/{path}/{file}.md`
+- Portuguese translation: `packages/docs/site/i18n/pt/docusaurus-plugin-content-docs/current/{path}/{file}.md`
+- Language code: `pt` (Brazilian Portuguese)
+
+## Synchronization Workflow
+
+### For Updated English Pages
+
+When English documentation is updated:
+
+1. **Identify outdated translations** by searching for the old English content in HTML comments
+2. **Update the Portuguese file** with:
+   ```markdown
+   <!--
+   Updated English content here
+   -->
+   
+   Conteúdo traduzido em português brasileiro aqui
+   ```
+3. **Maintain consistency** with existing Portuguese terminology and style
+4. **Preserve all markdown structure** including headers, links, code blocks, and formatting
+
+### For New English Pages
+
+When new pages are added to trunk:
+
+1. **Create corresponding Portuguese file** at the mirrored path structure
+2. **Copy original English content** into HTML comments at the top
+3. **Add complete Brazilian Portuguese translation** below the comments
+4. **Follow WordPress Portuguese localization standards**
+
+## Brazilian Portuguese Standards
+
+### Language Guidelines
+
+- Use Brazilian Portuguese variants (not European Portuguese)
+- Maintain formal tone consistent with technical documentation
+- Keep technical terms in English when commonly used (e.g., "WordPress", "plugin", "theme")
+- Use WordPress.org Brazilian translation conventions
+
+### Common Technical Terms
+
+- Plugin → Plugin (unchanged)
+- Theme → Tema  
+- Dashboard → Painel
+- Widget → Widget (unchanged)
+- Shortcode → Shortcode (unchanged)
+- Playground → Playground (unchanged)
+- Blueprint → Blueprint (unchanged)
+
+### Content Structure
+
+Always include English reference content:
+```markdown
+<!--
+English content for reference - do not translate this section
+-->
+
+# Título em Português
+
+Conteúdo traduzido mantendo toda formatação markdown, links e estrutura do original.
+```
+
+## PR Guidelines for Portuguese Updates
+
+### PR Title Format
+- Sync updates: `[i18n-pt] Sincronizar [nome da página] com versão em inglês`
+- New translations: `[i18n-pt] Adicionar tradução para [nome da página]`
+
+### PR Description Template
+```
+## Tipo de atualização
+- [ ] Sincronização com versão em inglês atualizada
+- [ ] Nova tradução de página adicionada
+
+## Páginas afetadas
+- lista das páginas modificadas ou adicionadas
+
+## Verificações realizadas
+- [ ] Estrutura de arquivos espelha o original
+- [ ] Conteúdo inglês original preservado em comentários
+- [ ] Links e referências funcionam corretamente
+- [ ] Terminologia consistente com padrões WordPress Brasil
+```
+
+## Testing Commands
+
+From `packages/docs/site` directory:
+- Test Portuguese site: `npm run dev -- --locale pt`
+- Build with Portuguese: `npm run build:docs`
+- Generate Portuguese UI strings: `npm run write-translations -- --locale pt`
+
+## Maintenance Automation
+
+### Regular Sync Tasks
+1. Monitor English documentation changes in trunk
+2. Update corresponding Portuguese files within 1-2 weeks of English updates
+3. Create tracking issues for major documentation additions
+4. Coordinate with WordPress.org Portuguese translation team when needed
+
+### Quality Assurance
+- All Portuguese pages must build successfully
+- Links between Portuguese pages must work correctly  
+- Navigation and UI elements should display in Portuguese
+- Code examples remain functional with Portuguese context

--- a/.github/instructions/TRANSLATIONS.instructions.md
+++ b/.github/instructions/TRANSLATIONS.instructions.md
@@ -1,0 +1,87 @@
+# Translation Instructions for WordPress Playground
+
+## Project Overview
+
+WordPress Playground is a web-based tool for experimenting with WordPress. The documentation is built with Docusaurus and supports internationalization (i18n) with translations stored in `packages/docs/site/i18n/` organized by language codes.
+
+## File Structure for Translations
+
+- Base documentation: `packages/docs/site/docs/`
+- Translations directory: `packages/docs/site/i18n/{LANGUAGE_CODE}/docusaurus-plugin-content-docs/current/`
+- Configuration: `packages/docs/site/docusaurus.config.js`
+- Assets: `packages/docs/site/static/img/`
+
+## Translation Production Guidelines
+
+When creating or updating translations:
+
+1. **File Structure**: Always mirror the exact directory structure from the original English docs
+   - Original: `docs/main/intro.md`
+   - Translation: `i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`
+
+2. **Content Format**: Include original English content as HTML comments above translations
+   ```markdown
+   <!--
+   Original English content here for reviewer reference
+   -->
+   
+   Translated content here
+   ```
+
+3. **Naming Conventions**: 
+   - Use standard language codes (es, fr, pt, etc.)
+   - Maintain original file names exactly
+   - Keep `.md` extensions
+
+4. **PR Guidelines**:
+   - Add `[i18n]` prefix to PR titles
+   - Submit small batches of translated pages
+   - Reference tracking issues when they exist
+
+## Translation Review Standards
+
+When reviewing translation PRs:
+
+1. **Structure Verification**:
+   - Confirm file paths match original structure exactly
+   - Check that frontmatter and metadata are preserved
+   - Verify links and references work correctly
+
+2. **Content Matching**:
+   - Verify translated content corresponds to the original English sections
+   - Check that all paragraphs, headings, and sections are translated
+   - Ensure no content is missing or added unexpectedly
+   - Original English text in HTML comments is for reference only - do not review comment content
+
+3. **Translation Quality**:
+   - Translation should maintain technical accuracy
+   - UI elements and navigation terms should be consistent
+   - Code blocks and examples remain functional
+   - Markdown formatting preserved in translated content
+
+4. **Completeness Check**:
+   - All sections from original document are present in translation
+   - Image paths and alt text appropriately handled
+   - Links and cross-references work correctly
+
+## Configuration Updates
+
+When adding new languages to the language switcher:
+
+- Only add languages with significant documentation coverage (entire "Documentation" hub)
+- Update `docusaurus.config.js` with new locale configuration
+- Generate UI translation files using `npm run write-translations -- --locale <LANGUAGE_CODE>`
+
+## Testing Commands
+
+From `packages/docs/site` directory:
+- Test specific language: `npm run dev -- --locale <LANGUAGE_CODE>`
+- Build all languages: `npm run build:docs`
+- Generate translation files: `npm run write-translations -- --locale <LANGUAGE_CODE>`
+
+## Common Patterns
+
+- Preserve all markdown syntax and formatting
+- Keep code examples in original language unless specifically localizing
+- Maintain consistent terminology across translation files
+- Follow WordPress translation standards and conventions


### PR DESCRIPTION
This pull request adds comprehensive instructions for maintaining and reviewing translations of WordPress Playground documentation, with a new focus on Brazilian Portuguese and general translation workflows. The changes introduce two new instruction documents to guide contributors on file structure, translation standards, synchronization, PR guidelines, and testing procedures.

**Brazilian Portuguese Translation Maintenance**:

* Added `.github/instructions/BRAZILIAN-TRANSLATIONS.instructions.md` detailing the workflow for keeping Brazilian Portuguese (`pt-BR`) documentation in sync with English, including file structure, language standards, terminology, PR formats, and automation/testing commands.

**General Translation Guidelines**:

* Added `.github/instructions/TRANSLATIONS.instructions.md` outlining the overall translation process for all supported languages, including directory structure, content formatting, PR and review guidelines, configuration for new languages, and testing commands.
